### PR TITLE
Bumped up minimum boto3 version for new regional support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,9 +81,13 @@ celerybeat-schedule
 # virtualenv
 venv/
 ENV/
+venv
 
 # Spyder project settings
 .spyderproject
 
 # Rope project settings
 .ropeproject
+
+# IntelliJ/PyCharm
+.idea/

--- a/cloudaux/__about__.py
+++ b/cloudaux/__about__.py
@@ -13,7 +13,7 @@ __title__ = 'cloudaux'
 __summary__ = 'Cloud Auxiliary is a python wrapper and orchestration module for interacting with cloud providers'
 __uri__ = 'https://github.com/Netflix-Skunkworks/cloudaux'
 
-__version__ = '1.0.4'
+__version__ = '1.0.5'
 
 __author__ = 'Patrick Kelley'
 __email__ = 'patrick@netflix.com'

--- a/cloudaux/orchestration/aws/s3.py
+++ b/cloudaux/orchestration/aws/s3.py
@@ -302,7 +302,7 @@ def get_bucket(bucket_name, output='camelized', include_created=False, **conn):
         'notifications': get_notifications(bucket_name, **conn),
         'acceleration': get_acceleration(bucket_name, **conn),
         'replication': get_replication(bucket_name, **conn),
-        '_version': 2
+        '_version': 3
     }
 
     if include_created:

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ with open(os.path.join(ROOT, "cloudaux", "__about__.py")) as f:
     exec(f.read(), about)
 
 install_requires = [
-    'boto3>=1.3.1',
+    'boto3>=1.4.1',
     'boto>=2.41.0',
     'joblib>=0.9.4',
     'inflection'


### PR DESCRIPTION
- Version now 1.0.5
- Newest version addresses issues with "AWS4-HMAC-SHA256"
  that is required for newer AWS regions (like us-east-2).
- Updated `_version` to `3` for `get_bucket` to reflect changes in #8.