### PR TITLE
Casting more dates to strings for JSON serialization

### DIFF
--- a/cloudaux/__about__.py
+++ b/cloudaux/__about__.py
@@ -13,7 +13,7 @@ __title__ = 'cloudaux'
 __summary__ = 'Cloud Auxiliary is a python wrapper and orchestration module for interacting with cloud providers'
 __uri__ = 'https://github.com/Netflix-Skunkworks/cloudaux'
 
-__version__ = '1.0.6'
+__version__ = '1.0.7'
 
 __author__ = 'Patrick Kelley'
 __email__ = 'patrick@netflix.com'

--- a/cloudaux/aws/iam.py
+++ b/cloudaux/aws/iam.py
@@ -250,6 +250,10 @@ def _get_user_signing_certificates(user, client=None, **kwargs):
 @rate_limited()
 def get_user_signing_certificates(user, client=None, **kwargs):
     certificates = _get_user_signing_certificates(user, client=client, **kwargs)
+    for certificate in certificates:
+        if 'UploadDate' in certificate:
+            certificate['UploadDate'] = str(certificate['UploadDate'])
+
     return {certificate['CertificateId']: dict(certificate) for certificate in certificates}
 
 


### PR DESCRIPTION
As a follow up to Netflix-Skunkworks/cloudaux#3 it appears that there's another spot which requires manual casting to string for JSON serialization. This was encountered when running security_monkey against an account with per IAM User Signing Certificates which had an `UploadDate` field.

A link to the GitHub issue in the security_monkey project will be provided here shortly for reference.

As an aside, I wasn't able to find any contribution guidelines for this project, but I may just not be looking hard enough. That said, please let me know if any changes are required to suit preferences, etc :)

Cheers,
Peter