### PR TITLE
[GCP] add firewall fetching support

### DIFF
--- a/cloudaux/__about__.py
+++ b/cloudaux/__about__.py
@@ -13,7 +13,7 @@ __title__ = 'cloudaux'
 __summary__ = 'Cloud Auxiliary is a python wrapper and orchestration module for interacting with cloud providers'
 __uri__ = 'https://github.com/Netflix-Skunkworks/cloudaux'
 
-__version__ = '1.1.1'
+__version__ = '1.1.2'
 
 __author__ = 'Patrick Kelley'
 __email__ = 'patrick@netflix.com'

--- a/cloudaux/gcp/README.md
+++ b/cloudaux/gcp/README.md
@@ -159,6 +159,42 @@ Cloud Auxiliary has support for Google Cloud Platform.
         "StorageClass": "MULTI_REGIONAL",
         "VersioningEnabled": false
     }
+## Firewall Rules
+### List Rules
+    from cloudaux.gcp.gce.firewall import list_firewall_rules
+    rules = list_firewall_rules(**conn_details)
+    for rule in rules:
+      print(json.dumps(rule, indent=4, sort_keys=True))
+
+### Get Single Rule
+    # get single rule
+    from cloudaux.gcp.gce.firewall import get_firewall_rule
+    rule = get_firewall_rule(Firewall='default-allow-http', **conn_details)
+    print(json.dumps(rule, indent=4, sort_keys=True))
+
+    {
+        "allowed": [
+            {
+                "IPProtocol": "tcp",
+                "ports": [
+                    "80"
+                ]
+            }
+        ],
+        "creationTimestamp": "2016-10-03T11:10:37.412-07:00",
+        "description": "",
+        "id": "6048401367777616399",
+        "kind": "compute#firewall",
+        "name": "default-allow-http",
+        "network": "https://www.googleapis.com/compute/v1/projects/my-project/global/networks/default",
+        "selfLink": "https://www.googleapis.com/compute/v1/projects/my-project/global/firewalls/default-allow-http",
+        "sourceRanges": [
+            "0.0.0.0/0"
+        ],
+        "targetTags": [
+            "http-server"
+        ]
+    }
 
 ## Function Stats
     from cloudaux.gcp.utils import get_gcp_stats

--- a/cloudaux/gcp/gce/firewall.py
+++ b/cloudaux/gcp/gce/firewall.py
@@ -1,0 +1,24 @@
+"""
+.. module: cloudaux.gcp.gce.firewall
+    :platform: Unix
+    :copyright: (c) 2016 by Google Inc., see AUTHORS for more
+    :license: Apache, see LICENSE for more details.
+.. moduleauthor:: Tom Melendez (@supertom) <supertom@google.com>
+"""
+from cloudaux.gcp.utils import gce_list
+from cloudaux.gcp.decorators import gcp_conn
+
+@gcp_conn('gce')
+def list_firewall_rules(client=None, **kwargs):
+    """
+    :rtype: ``list``
+    """
+    return gce_list(service=client.firewalls(),
+                        **kwargs)
+
+@gcp_conn('gce')
+def get_firewall_rule(client=None, **kwargs):
+    service = client.firewalls()
+    req = service.get(project=kwargs['project'], firewall=kwargs['Firewall'])
+    resp = req.execute()
+    return resp


### PR DESCRIPTION
Support for firewall list and get calls.

(There is no orchestration as there is currently nothing to orchestrate.  I suspect that will change as we need things like "which networks does a firewall apply to" or which instances contain the target tags this firewall rule contains".)