### PR TITLE
Adding ELBv1 Orchestration and version bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ AWS:
  - IAM Role
  - IAM User
  - S3
+ - ELB (v1)
 
 GCP:
  - IAM Service Accounts

--- a/cloudaux/__about__.py
+++ b/cloudaux/__about__.py
@@ -13,7 +13,7 @@ __title__ = 'cloudaux'
 __summary__ = 'Cloud Auxiliary is a python wrapper and orchestration module for interacting with cloud providers'
 __uri__ = 'https://github.com/Netflix-Skunkworks/cloudaux'
 
-__version__ = '1.2.0'
+__version__ = '1.2.1'
 
 __author__ = 'Patrick Kelley'
 __email__ = 'patrick@netflix.com'

--- a/cloudaux/aws/README.md
+++ b/cloudaux/aws/README.md
@@ -22,6 +22,7 @@ Cloud Auxiliary has support for Amazon Web Services.
  - IAM Role
  - IAM User
  - S3
+ - ELB (v1)
 
 ## Install
 
@@ -338,3 +339,109 @@ Cloud Auxiliary has support for Amazon Web Services.
     }
     
     **NOTE: "GrantReferences" is an ephemeral field -- it is not guaranteed to be consistent - do not base logic off of it**
+
+## ELB (v1)
+
+    from cloudaux.orchestration.aws.elb import get_load_balancer, FLAGS
+    
+    conn = dict(
+        account_number='000000000000',
+        assume_role='SecurityMonkey')
+    
+    load_balancer = get_load_balancer('MyELB', flags=FLAGS.ALL, **conn)
+    
+    # The flags parameter is optional but allows the user to indicate that 
+    # only a subset of the full item description is required.
+    # S3 Flag Options are:
+    #   BASE, ATTRIBUTES, TAGS
+    # For instance: flags=FLAGS.BASE | FLAGS.TAGS
+    
+    print(json.dumps(load_balancer, indent=2, sort_keys=True))
+    
+    {
+      "Arn": "arn:aws:elasticloadbalancing:us-east-1:000000000000:loadbalancer/MyELB",
+      "Attributes": {
+        "AccessLog": {
+          "EmitInterval": 5,
+          "Enabled": true,
+          "S3BucketName": "elb-log-bucket",
+          "S3BucketPrefix": "MyELB"
+        },
+        "ConnectionDraining": {
+          "Enabled": false,
+          "Timeout": 300
+        },
+        "ConnectionSettings": {
+          "IdleTimeout": 60
+        },
+        "CrossZoneLoadBalancing": {
+          "Enabled": false
+        }
+      },
+      "AvailabilityZones": [
+        "us-east-1b"
+      ],
+      "BackendServerDescriptions": [],
+      "CanonicalHostedZoneNameID": "ZXXXXXXXXXXXXX",
+      "CreatedTime": "2015-07-07 19:15:06.490000+00:00",
+      "DNSName": "internal-MyELB-1800000000.us-east-1.elb.amazonaws.com",
+      "HealthCheck": {
+        "HealthyThreshold": 2,
+        "Interval": 30,
+        "Target": "HTTP:80/health",
+        "Timeout": 5,
+        "UnhealthyThreshold": 2
+      },
+      "Instances": [],
+      "ListenerDescriptions": [
+        {
+          "Listener": {
+            "InstancePort": 443,
+            "InstanceProtocol": "TCP",
+            "LoadBalancerPort": 443,
+            "Protocol": "TCP"
+          },
+          "PolicyNames": []
+        },
+        {
+          "Listener": {
+            "InstancePort": 80,
+            "InstanceProtocol": "HTTP",
+            "LoadBalancerPort": 80,
+            "Protocol": "HTTP"
+          },
+          "PolicyNames": []
+        }
+      ],
+      "LoadBalancerName": "MyELB",
+      "Policies": {
+        "AppCookieStickinessPolicies": [],
+        "LBCookieStickinessPolicies": [],
+        "OtherPolicies": []
+      },
+      "Region": "us-east-1",
+      "Scheme": "internal",
+      "SecurityGroups": [
+        "sg-19999999"
+      ],
+      "SourceSecurityGroup": {
+        "GroupName": "MyELB-SecurityGroup",
+        "OwnerAlias": "000000000000"
+      },
+      "Subnets": [
+        "subnet-19999999"
+      ],
+      "Tags": [
+        {
+          "LoadBalancerName": "MyELB",
+          "Tags": [
+            {
+              "Key": "tagkey",
+              "Value": "tagvalue"
+            }
+          ]
+        }
+      ],
+      "VPCId": "vpc-49999999",
+      "_version": 1
+    }

--- a/cloudaux/aws/decorators.py
+++ b/cloudaux/aws/decorators.py
@@ -59,7 +59,7 @@ def paginated(response_key, request_pagination_marker="Marker", response_paginat
                 response = func(*args, **kwargs)
                 results.extend(response[response_key])
 
-                if response['IsTruncated']:
+                if ('NextMarker' in response) or ('IsTruncated' in response and response['IsTruncated']):
                     kwargs.update({request_pagination_marker: response[response_pagination_marker]})
                 else:
                     break

--- a/cloudaux/aws/ec2.py
+++ b/cloudaux/aws/ec2.py
@@ -26,14 +26,6 @@ def create_group(group, account_number=None, region=None, assume_role=None, clie
                 Description=group.description
         )['GroupId']
 
-    # by default if we have a vpc sg we will allow all out bound
-    client.authorize_security_group_egress(
-            GroupId=group_id,
-            IpProtocol='tcp',
-            FromPort=0,
-            ToPort=65535,
-            CidrIp='0.0.0.0/0'
-    )
     return group_id
 
 

--- a/cloudaux/aws/elb.py
+++ b/cloudaux/aws/elb.py
@@ -6,7 +6,6 @@
 .. moduleauthor:: Patrick Kelley <patrick@netflix.com>
 """
 from cloudaux.aws.sts import sts_conn
-from cloudaux.exceptions import CloudAuxException
 from cloudaux.aws.decorators import rate_limited
 from cloudaux.aws.decorators import paginated
 

--- a/cloudaux/aws/elb.py
+++ b/cloudaux/aws/elb.py
@@ -1,0 +1,47 @@
+"""
+.. module: cloudaux.aws.elb
+    :platform: Unix
+    :copyright: (c) 2017 by Netflix Inc., see AUTHORS for more
+    :license: Apache, see LICENSE for more details.
+.. moduleauthor:: Patrick Kelley <patrick@netflix.com>
+"""
+from cloudaux.aws.sts import sts_conn
+from cloudaux.exceptions import CloudAuxException
+from cloudaux.aws.decorators import rate_limited
+from cloudaux.aws.decorators import paginated
+
+
+@paginated('LoadBalancerDescriptions', response_pagination_marker='NextMarker')
+@sts_conn('elb')
+@rate_limited()
+def describe_load_balancers(client=None, **kwargs):
+    return client.describe_load_balancers(**kwargs)
+
+
+@sts_conn('elb')
+@rate_limited()
+def describe_load_balancer_attributes(load_balancer_name, client=None):
+    return client.describe_load_balancer_attributes(
+        LoadBalancerName=load_balancer_name)['LoadBalancerAttributes']
+
+
+@sts_conn('elb')
+@rate_limited()
+def describe_load_balancer_policies(load_balancer_name, policy_names, client=None):
+    return client.describe_load_balancer_policies(
+        LoadBalancerName=load_balancer_name,
+        PolicyNames=policy_names)['PolicyDescriptions']
+
+
+@sts_conn('elb')
+@rate_limited()
+def describe_load_balancer_policy_types(policy_type_names, client=None):
+    return client.describe_load_balancer_policy_types(
+        PolicyTypeNames=policy_type_names)['PolicyTypeDescriptions']
+
+
+@sts_conn('elb')
+@rate_limited()
+def describe_tags(load_balancer_names, client=None):
+    return client.describe_tags(
+        LoadBalancerNames=load_balancer_names)['TagDescriptions']

--- a/cloudaux/orchestration/aws/elb.py
+++ b/cloudaux/orchestration/aws/elb.py
@@ -1,0 +1,46 @@
+from cloudaux.aws.elb import *
+from cloudaux.orchestration import modify
+from cloudaux.orchestration.flag_registry import FlagRegistry, Flags
+
+class ELBFlagRegistry(FlagRegistry):
+    from collections import defaultdict
+    r = defaultdict(list)
+
+FLAGS = Flags('BASE', 'ATTRIBUTES', 'TAGS')
+
+
+@ELBFlagRegistry.register(flag=FLAGS.ATTRIBUTES, key='attributes')
+def get_attributes(load_balancer_name, **conn):
+    return describe_load_balancer_attributes(load_balancer_name, **conn)
+
+
+@ELBFlagRegistry.register(flag=FLAGS.TAGS, key='tags')
+def get_tags(load_balancer_name, **conn):
+    return describe_tags([load_balancer_name], **conn)
+
+
+@ELBFlagRegistry.register(flag=FLAGS.BASE)
+def get_base(load_balancer_name, **conn):
+    load_balancer = describe_load_balancers(LoadBalancerNames=[load_balancer_name], **conn)
+    load_balancer = load_balancer[0]
+    load_balancer['CreatedTime'] = str(load_balancer['CreatedTime'])
+
+    # Amazingly, boto3 does not return an ARN, so let's build it ourselves.
+    arn = 'arn:aws:elasticloadbalancing:{region}:{account_id}:loadbalancer/{name}'
+    arn = arn.format(
+        region=conn.get('region'),
+        account_id=conn.get('account_number'),
+        name=load_balancer_name)
+
+    load_balancer.update({
+        'arn': arn,
+        'region': conn.get('region'),
+        '_version': 1
+    })
+    return load_balancer
+
+
+def get_load_balancer(load_balancer_name, output='camelized', flags=FLAGS.ALL, **conn):
+    result = dict()
+    ELBFlagRegistry.build_out(result, flags, load_balancer_name, **conn)
+    return modify(result, format=output)


### PR DESCRIPTION
Advantages over security_monkey ELB watcher:
- boto3
- Adds Tags
- Adds Attributes

Of Concern:
- The boto3 call `describe_load_balancers()` returns a list of all instances attached to the ELB.  There does not appear to be a way to disable this.  We may wish to remove this field when used for security_monkey so we're not overwhelmed.