### PR TITLE
Separating some of the GCP requirements (which can be quite large) into a setup-extras.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,8 @@ env:
     - GOOGLE_APPLICATION_CREDENTIALS=$TRAVIS_BUILD_DIR/tests/gcp/fixtures/testkey.json
 
 before_script:
-  - python setup.py develop
+# - python setup.py develop
+  - pip install -e .\[gcp\]
   - pip install pytest
   - pip install mock
   - pip install coveralls

--- a/README.md
+++ b/README.md
@@ -51,7 +51,11 @@ GCP:
 ## Install
 
     pip install cloudaux
-    
+
+For GCP support run:
+
+    pip install cloudaux\[gcp\]
+
 ## Examples
 
 

--- a/cloudaux/__about__.py
+++ b/cloudaux/__about__.py
@@ -13,7 +13,7 @@ __title__ = 'cloudaux'
 __summary__ = 'Cloud Auxiliary is a python wrapper and orchestration module for interacting with cloud providers'
 __uri__ = 'https://github.com/Netflix-Skunkworks/cloudaux'
 
-__version__ = '1.2.9'
+__version__ = '1.3.0'
 
 __author__ = 'Patrick Kelley'
 __email__ = 'patrick@netflix.com'

--- a/cloudaux/aws/README.md
+++ b/cloudaux/aws/README.md
@@ -30,6 +30,10 @@ Cloud Auxiliary has support for Amazon Web Services.
 
     pip install cloudaux
 
+For GCP support run:
+
+    pip install cloudaux\[gcp\]
+
 ## Example
 
     # Using wrapper methods:

--- a/cloudaux/gcp/README.md
+++ b/cloudaux/gcp/README.md
@@ -26,6 +26,10 @@ Cloud Auxiliary has support for Google Cloud Platform.
 
     pip install cloudaux
 
+For GCP support run:
+
+    pip install cloudaux\[gcp\]
+
 ## Authentication/Authorization
 
  - Default Credentials (if running on GCE)

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,9 @@ install_requires = [
     'inflection',
     'flagpole>=1.0.1',
     'defusedxml==0.5.0',
+]
+
+gcp_require = [
     'google-api-python-client>=1.6.1',
     'google-cloud-storage==0.22.0'
 ]
@@ -57,6 +60,7 @@ setup(
     zip_safe=False,
     install_requires=install_requires,
     extras_require={
+        'gcp': gcp_require,
         'tests': tests_require,
         'docs': docs_require,
         'dev': dev_require


### PR DESCRIPTION
The GCP dependencies made the library so big we were having difficulty using it with lambdas.

Docs say to use `pip install cloudaux\[gcp\]` so that it works in zsh.  (Was having trouble with `pip install cloudaux['gcp']` and `pip install "cloudaux['gcp']"` on my box for some reason.