### PR TITLE
Get new session for client/resource creation

### DIFF
--- a/cloudaux/aws/sts.py
+++ b/cloudaux/aws/sts.py
@@ -29,14 +29,14 @@ def _conn_kwargs(region, role):
 
 
 def _client(service, region, role):
-    return boto3.client(
+    return boto3.session.Session().client(
         service,
         **_conn_kwargs(region, role)
     )
 
 
 def _resource(service, region, role):
-    return boto3.resource(
+    return boto3.session.Session().resource(
         service,
         **_conn_kwargs(region, role)
     )
@@ -88,7 +88,7 @@ def boto3_cached_conn(service, service_type='client', future_expiration_minutes=
 
     role = None
     if assume_role:
-        sts = boto3.client('sts')
+        sts = boto3.session.Session().client('sts')
 
         # prevent malformed ARN
         if not all([account_number, assume_role]):


### PR DESCRIPTION
Resolves a bug where client creation would fail for all threads but the first in multithreaded use cases (e.g. https://github.com/Netflix-Skunkworks/aardvark/issues/14) by creating a new session for each client/resource. This avoids problems with reusing the default session and lines up with boto3 recommendations for multithreaded scenarios: http://boto3.readthedocs.io/en/latest/guide/resources.html?highlight=multithreading#multithreading-multiprocessing.

Discussion/feedback welcome.