### PR TITLE
Updated S3 CreationDate Schema

### DIFF
--- a/cloudaux/__about__.py
+++ b/cloudaux/__about__.py
@@ -13,7 +13,7 @@ __title__ = 'cloudaux'
 __summary__ = 'Cloud Auxiliary is a python wrapper and orchestration module for interacting with cloud providers'
 __uri__ = 'https://github.com/Netflix-Skunkworks/cloudaux'
 
-__version__ = '1.3.7'
+__version__ = '1.3.8'
 
 __author__ = 'Patrick Kelley'
 __email__ = 'patrick@netflix.com'

--- a/cloudaux/aws/README.md
+++ b/cloudaux/aws/README.md
@@ -342,8 +342,8 @@ For GCP support run:
           }
         }
       ],
-      "Created": "2017-03-16 10:00:00+00:00",
-      "_version": 5
+      "CreationDate": "2017-09-07T22:28:01Z",
+      "_version": 8
     }
     
     **NOTE: "GrantReferences" is an ephemeral field -- it is not guaranteed to be consistent - do not base logic off of it**

--- a/cloudaux/orchestration/aws/s3.py
+++ b/cloudaux/orchestration/aws/s3.py
@@ -89,6 +89,7 @@ def get_lifecycle(bucket_name, **conn):
 
     return result['Rules']
 
+
 @registry.register(flag=FLAGS.LOGGING, key='logging')
 def get_logging(bucket_name, **conn):
     result = get_bucket_logging(Bucket=bucket_name, **conn)
@@ -238,10 +239,12 @@ def get_replication(bucket_name, **conn):
     return result["ReplicationConfiguration"]
 
 
-@registry.register(flag=FLAGS.CREATED_DATE, key='created')
+@registry.register(flag=FLAGS.CREATED_DATE, key='creation_date')
 def get_bucket_created(bucket_name, **conn):
     bucket = get_bucket_resource(bucket_name, **conn)
-    return str(bucket.creation_date)
+
+    # Return the creation date as a Proper ISO 8601 String:
+    return bucket.creation_date.replace(tzinfo=None, microsecond=0).isoformat() + "Z"
 
 
 @registry.register(flag=FLAGS.ANALYTICS, key='analytics_configurations')
@@ -265,7 +268,7 @@ def get_base(bucket_name, **conn):
         'arn': "arn:aws:s3:::{name}".format(name=bucket_name),
         'name': bucket_name,
         'region': conn.get('region'),
-        '_version': 7
+        '_version': 8
     }
 
 
@@ -290,11 +293,11 @@ def get_bucket(bucket_name, include_created=None, flags=FLAGS.ALL ^ FLAGS.CREATE
         "Notifications": ...,
         "Acceleration": ...,
         "Replication": ...,
-        "Created": ...,
+        "CreationDate": ...,
         "AnalyticsConfigurations": ...,
         "MetricsConfigurations": ...,
         "InventoryConfigurations": ...,
-        "_version": 6
+        "_version": 8
     }
 
     NOTE: "GrantReferences" is an ephemeral field that is not guaranteed to be consistent -- do not base logic off of it


### PR DESCRIPTION
- Returns proper ISO 8601 string
- Renamed field to `CreationDate` to be consistent with AWS