### PR TITLE
Fix for ELB policy attribute string values.

### DIFF
--- a/cloudaux/orchestration/aws/elb.py
+++ b/cloudaux/orchestration/aws/elb.py
@@ -25,7 +25,12 @@ def _reformat_policy(policy):
 
     attributes = dict()
     for attr in attrs:
-        attributes[attr['AttributeName']] = attr['AttributeValue']
+        if attr['AttributeValue'] == "true":
+            attributes[attr['AttributeName']] = True
+        elif attr['AttributeValue'] == "false":
+            attributes[attr['AttributeName']] = False
+        else:
+            attributes[attr['AttributeName']] = attr['AttributeValue']
 
     ret['protocols'] = dict()
     ret['protocols']['sslv2'] = bool(attributes.get('Protocol-SSLv2'))


### PR DESCRIPTION
This fixes the false positives reported by the ELB Policy watcher. Boto3 returns these policy attribute values as strings, and these values are generally string "true" or string "false". In Python, bool("false") is actually True. This is the same code that SecurityMonkey used in versions 8.0 and before.

https://github.com/Netflix/security_monkey/blob/v0.8.0/security_monkey/watchers/elb.py#L87
http://boto3.readthedocs.io/en/latest/reference/services/elb.html#ElasticLoadBalancing.Client.describe_load_balancer_policies