### PR TITLE
Migrate away from caching botocore sessions

### DIFF
--- a/cloudaux/__about__.py
+++ b/cloudaux/__about__.py
@@ -13,7 +13,7 @@ __title__ = 'cloudaux'
 __summary__ = 'Cloud Auxiliary is a python wrapper and orchestration module for interacting with cloud providers'
 __uri__ = 'https://github.com/Netflix-Skunkworks/cloudaux'
 
-__version__ = '1.4.6'
+__version__ = '1.4.7'
 
 __author__ = 'Patrick Kelley'
 __email__ = 'patrick@netflix.com'


### PR DESCRIPTION
This addresses a massive memory leaking problem that appears to be introduced in newer botocore versions (>1.7). The memory leakage appears to happen when caching the botocore sessions.

This modifies the behavior of CloudAux so that it only caches the credentials instead of the botocore sessions. This will generate brand new botocore sessions each time with the cached credentials.  Doing this has been shown to _**massively**_ reduce the memory footprint to normal levels.