### PR TITLE
Support both Python and legacy Python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: python
 matrix:
   include:
     - python: "2.7"
-    - python: "3.5"
+    - python: "3.6"
 
 cache:
   directories:
@@ -17,11 +17,18 @@ env:
 before_script:
 # - python setup.py develop
   - pip install -e .\[gcp\]
+  - pip install flake8
   - pip install pytest
   - pip install mock
   - pip install coveralls
 
 script:
+  # stop the build if there are Python syntax errors or undefined names
+  # FIXME: Add F821 to --select when Netflix-Skunkworks/cloudaux#63 is fixed
+  # ./cloudaux/aws/sns.py:132:2: F821 undefined name 'pagiated'
+  - flake8 . --count --select=E901,E999,F822,F823 --show-source --statistics
+  # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+  - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
   - coverage run -m py.test tests || exit 1
 
 after_success:

--- a/cloudaux/__about__.py
+++ b/cloudaux/__about__.py
@@ -13,7 +13,7 @@ __title__ = 'cloudaux'
 __summary__ = 'Cloud Auxiliary is a python wrapper and orchestration module for interacting with cloud providers'
 __uri__ = 'https://github.com/Netflix-Skunkworks/cloudaux'
 
-__version__ = '1.4.7'
+__version__ = '1.4.8'
 
 __author__ = 'Patrick Kelley'
 __email__ = 'patrick@netflix.com'

--- a/cloudaux/gcp/decorators.py
+++ b/cloudaux/gcp/decorators.py
@@ -6,8 +6,9 @@
 .. moduleauthor:: Tom Melendez (@supertom) <supertom@google.com>
 """
 import time
-
 from functools import wraps
+
+from six import string_types
 
 from cloudaux.gcp.gcpcache import GCPCache
 from cloudaux.gcp.utils import get_creds_from_kwargs, rewrite_kwargs
@@ -48,7 +49,7 @@ def gcp_conn(service, service_type='client', future_expiration_minutes=15):
 def gcp_stats():
     """
     Collect stats
-    
+
     Specifically, time function calls
     :returns: function response
     :rtype: varies
@@ -102,10 +103,10 @@ def iter_project(projects, key_file=None):
     Note: the function 'decorated' is expected to return a value plus a dictionary of exceptions.
 
     If item in list is a dictionary, we look for a 'project' and 'key_file' entry, respectively.
-    If item in list is of type basestring, we assume it is the project string. Default credentials
+    If item in list is of type string_types, we assume it is the project string. Default credentials
     will be used by the underlying client library.
 
-    :param projects: list of project strings or list of dictionaries 
+    :param projects: list of project strings or list of dictionaries
                      Example: {'project':..., 'keyfile':...}. Required.
     :type projects: ``list`` of ``str`` or ``list`` of ``dict``
 
@@ -122,7 +123,7 @@ def iter_project(projects, key_file=None):
             item_list = []
             exception_map = {}
             for project in projects:
-                if isinstance(project, basestring):
+                if isinstance(project, string_types):
                     kwargs['project'] = project
                     if key_file:
                         kwargs['key_file'] = key_file

--- a/cloudaux/openstack/decorators.py
+++ b/cloudaux/openstack/decorators.py
@@ -9,7 +9,7 @@ from functools import wraps
 
 from os_client_config import OpenStackConfig
 from openstack import connection
-
+from six.http.client import HTTPException
 
 """ this is mix of the aws and gcp decorator conventions """
 
@@ -37,7 +37,7 @@ def keystone_cached_conn(cloud_name, region, yaml_file):
         _cloud_name, conn = CACHE[key]
         try:
             conn.authorize()
-        except HttpException:
+        except HTTPException:
             del CACHE[key]
         else:
             return conn
@@ -53,7 +53,7 @@ def openstack_conn():
     def decorator(f):
         @wraps(f)
         def decorated_function(*args, **kwargs):
-            kwargs['conn'] = keystone_cached_conn( 
+            kwargs['conn'] = keystone_cached_conn(
 				kwargs.pop('cloud_name'), kwargs.pop('region'), kwargs.pop('yaml_file') )
             return f(*args, **kwargs)
 

--- a/cloudaux/orchestration/aws/glacier.py
+++ b/cloudaux/orchestration/aws/glacier.py
@@ -2,6 +2,7 @@ from cloudaux.aws.glacier import describe_vault, get_vault_access_policy, list_t
 from cloudaux.decorators import modify_output
 from cloudaux.orchestration.aws.arn import ARN
 from flagpole import FlagRegistry, Flags
+from six import string_types
 
 registry = FlagRegistry()
 FLAGS = Flags('BASE', 'POLICY', 'TAGS')
@@ -52,7 +53,7 @@ def get_vault(vault_obj, flags=FLAGS.ALL, **conn):
     Returns:
         dictionary describing the requested Vault
     """
-    if isinstance(vault_obj, basestring):
+    if isinstance(vault_obj, string_types):
         vault_arn = ARN(vault_obj)
         if vault_arn.error:
             vault_obj = {'VaultName': vault_obj}

--- a/cloudaux/orchestration/aws/iam/saml_provider.py
+++ b/cloudaux/orchestration/aws/iam/saml_provider.py
@@ -2,6 +2,7 @@ from cloudaux.aws.iam import get_saml_provider as boto_get_saml_provider
 from cloudaux.decorators import modify_output
 from flagpole import FlagRegistry, Flags
 import defusedxml.ElementTree as ET
+from six import string_types
 
 
 registry = FlagRegistry()
@@ -48,7 +49,7 @@ def get_base(provider, **conn):
 def get_saml_provider(provider, flags=FLAGS.ALL, **conn):
 
     # If provided an ARN, cast to a dict
-    if isinstance(provider, basestring):
+    if isinstance(provider, string_types):
         provider = dict(Arn=provider)
 
     return registry.build_out(flags, start_with=provider, pass_datastructure=True, **conn)

--- a/cloudaux/orchestration/openstack/utils.py
+++ b/cloudaux/orchestration/openstack/utils.py
@@ -7,8 +7,10 @@
 """
 import inspect
 
+from six import text_type
+
 """ global ignore_list for OpenStack SDK service object members """
-ignore_list = [ 'allow_create', 'allow_delete', 'allow_get', 'allow_head', 
+ignore_list = [ 'allow_create', 'allow_delete', 'allow_get', 'allow_head',
 		'allow_list', 'allow_update', 'patch_update', 'put_create',
 		'service', 'base_path', 'resource_key', 'resources_key' ]
 
@@ -17,7 +19,7 @@ def get_item(item, **kwargs):
     API versioning for each OpenStack service is independent. Generically capture
         the public members (non-routine and non-private) of the OpenStack SDK objects.
 
-    Note the lack of the modify_output decorator. Preserving the field naming allows 
+    Note the lack of the modify_output decorator. Preserving the field naming allows
         us to reconstruct objects and orchestrate from stored items.
     """
     _item = {}
@@ -28,13 +30,10 @@ def get_item(item, **kwargs):
     return sub_dict(_item)
 
 
-""" from security_monkey.common.utils. Need to convert any embedded OpenStack classes 
+""" from security_monkey.common.utils. Need to convert any embedded OpenStack classes
 			to their string/JSON representation """
 
-try:               # Python 2
-    prims = [int, str, unicode, bool, float, type(None)]
-except NameError:  # Python 3
-    prims = [int, str, bool, float, type(None)]
+prims = [int, str, text_type, bool, float, type(None)]
 
 def sub_list(l):
     """

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,15 @@ about = {}
 with open(os.path.join(ROOT, "cloudaux", "__about__.py")) as f:
     exec(f.read(), about)
 
+classifiers = [
+    'Programming Language :: Python :: 2',
+    'Programming Language :: Python :: 2.7',
+    'Programming Language :: Python :: 3',
+    'Programming Language :: Python :: 3.4',
+    'Programming Language :: Python :: 3.5',
+    'Programming Language :: Python :: 3.6',
+]
+
 install_requires = [
     'boto3>=1.5.20',
     'botocore>=1.8.34',
@@ -65,6 +74,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=install_requires,
+    classifiers=classifiers,
     extras_require={
         'gcp': gcp_require,
         'openstack': openstack_require,

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ install_requires = [
     'inflection',
     'flagpole>=1.0.1',
     'defusedxml==0.5.0',
+    'six>=1.11.0',
 ]
 
 gcp_require = [

--- a/tests/openstack/mock_utils.py
+++ b/tests/openstack/mock_utils.py
@@ -17,7 +17,7 @@ def mock_list_items(conn=None, **kwargs):
         generator = kwargs['generator']
         f = 'mock_list_%s'%generator
 
-	return globals()[f](conn, **kwargs)
+        return globals()[f](conn, **kwargs)
 
 def mock_list_networks(conn=None, **kwargs):
     with patch('openstack.connection.Connection'):
@@ -41,7 +41,7 @@ def mock_list_subnets(conn=None, **kwargs):
     with patch('openstack.connection.Connection'):
          from openstack.network.v2.subnet import Subnet
          from openstack.tests.unit.network.v2.test_subnet import EXAMPLE
-   
+
          conn = connection.Connection()
          conn.network.subnets.side_effect = [ [Subnet(**EXAMPLE)] ]
          return [x for x in conn.network.subnets()]


### PR DESCRIPTION
__NOTE__: This PR updates the `__version__` in cloudaux/__about__.py

* Adds the __six__ modules to fix __basestring__, __unicode__, imports, and TabError issue so that the codebase supports both Python 3 and Python 2.  It also adds __flake8__ to the testing to find syntax errors and undefined names.