### PR TITLE
Use openstack.exceptions.HttpException

### DIFF
--- a/cloudaux/__about__.py
+++ b/cloudaux/__about__.py
@@ -13,7 +13,7 @@ __title__ = 'cloudaux'
 __summary__ = 'Cloud Auxiliary is a python wrapper and orchestration module for interacting with cloud providers'
 __uri__ = 'https://github.com/Netflix-Skunkworks/cloudaux'
 
-__version__ = '1.4.8'
+__version__ = '1.4.9'
 
 __author__ = 'Patrick Kelley'
 __email__ = 'patrick@netflix.com'


### PR DESCRIPTION
__NOTE__: This PR updates the `__version__` in cloudaux/__about__.py

* The previous PR mistakenly used Python's __HTTPException__ instead of __openstack.exceptions.HttpException__.  This PR properly imports and uses the latter.

@mikegrima 