### PR TITLE
Error-handling for classic link not supported in all regions

### DIFF
--- a/cloudaux/__about__.py
+++ b/cloudaux/__about__.py
@@ -13,7 +13,7 @@ __title__ = 'cloudaux'
 __summary__ = 'Cloud Auxiliary is a python wrapper and orchestration module for interacting with cloud providers'
 __uri__ = 'https://github.com/Netflix-Skunkworks/cloudaux'
 
-__version__ = '1.4.12'
+__version__ = '1.4.13'
 
 __author__ = 'Patrick Kelley'
 __email__ = 'patrick@netflix.com'

--- a/cloudaux/orchestration/aws/vpc.py
+++ b/cloudaux/orchestration/aws/vpc.py
@@ -5,6 +5,8 @@
     :license: Apache, see LICENSE for more details.
 .. moduleauthor:: Mike Grima <mgrima@netflix.com>
 """
+from botocore.exceptions import ClientError
+
 from cloudaux.aws.ec2 import describe_vpcs, describe_dhcp_options, describe_vpc_classic_link, \
     describe_vpc_classic_link_dns_support, describe_internet_gateways, describe_vpc_peering_connections, \
     describe_subnets, describe_route_tables, describe_network_acls, describe_vpc_attribute
@@ -23,12 +25,17 @@ def get_classic_link(vpc, **conn):
     """"Gets the Classic Link details about a VPC"""
     result = {}
 
-    cl_result = describe_vpc_classic_link(VpcIds=[vpc["id"]], **conn)[0]
-    result["Enabled"] = cl_result["ClassicLinkEnabled"]
+    try:
+        cl_result = describe_vpc_classic_link(VpcIds=[vpc["id"]], **conn)[0]
+        result["Enabled"] = cl_result["ClassicLinkEnabled"]
 
-    # Check for DNS as well:
-    dns_result = describe_vpc_classic_link_dns_support(VpcIds=[vpc["id"]], **conn)[0]
-    result["DnsEnabled"] = dns_result["ClassicLinkDnsSupported"]
+        # Check for DNS as well:
+        dns_result = describe_vpc_classic_link_dns_support(VpcIds=[vpc["id"]], **conn)[0]
+        result["DnsEnabled"] = dns_result["ClassicLinkDnsSupported"]
+    except ClientError as e:
+        # This is not supported for all regions.
+        if 'UnsupportedOperation' not in str(e):
+            raise e
 
     return result
 

--- a/cloudaux/tests/aws/test_vpc_orchestration.py
+++ b/cloudaux/tests/aws/test_vpc_orchestration.py
@@ -6,6 +6,7 @@
 .. moduleauthor:: Mike Grima <mgrima@netflix.com>
 """
 import pytest
+from botocore.exceptions import ClientError
 
 from cloudaux.exceptions import CloudAuxException
 
@@ -71,6 +72,25 @@ def test_get_classic_link(test_vpc, dhcp_options, mock_classic_link):
 
     assert result["ClassicLink"]["Enabled"]
     assert result["ClassicLink"]["DnsEnabled"]
+    perform_base_tests(test_vpc, dhcp_options, result)
+
+
+def test_classic_link_exception(test_vpc, dhcp_options, mock_classic_link):
+    from cloudaux.orchestration.aws.vpc import get_vpc, get_classic_link, FLAGS
+
+    # Return an unsupported operation exception:
+    def raise_exception(**kwargs):
+        raise ClientError({"Error": {"Code": "UnsupportedOperation"}}, "DescribeVpcClassicLink")
+    mock_classic_link.describe_vpc_classic_link = raise_exception
+
+    result = get_classic_link({"id": test_vpc["VpcId"]}, force_client=mock_classic_link)
+    assert not result
+
+    # With BASE:
+    result = get_vpc(test_vpc["VpcId"], flags=FLAGS.CLASSIC_LINK, account_number="012345678912", region="us-east-1",
+                     force_client=mock_classic_link)
+
+    assert not result["ClassicLink"]
     perform_base_tests(test_vpc, dhcp_options, result)
 
 


### PR DESCRIPTION
Gracefully handles exceptions for unsupported ClassicLink regions.