### PR TITLE
Add AWS Security Group Get and Orchestration

### DIFF
--- a/cloudaux/aws/sg.py
+++ b/cloudaux/aws/sg.py
@@ -1,0 +1,28 @@
+from cloudaux.aws.decorators import rate_limited, paginated
+from cloudaux.aws.sts import sts_conn
+
+
+@sts_conn('ec2')
+@paginated('SecurityGroups', request_pagination_marker="nexttoken")
+@rate_limited()
+def list_security_groups(client=None, **kwargs):
+    return client.describe_security_groups()
+
+
+@sts_conn('ec2')
+@rate_limited()
+def describe_security_group(sg_id, client=None, **kwargs):
+    try:
+        sg_data = client.describe_security_groups(GroupIds=[sg_id])['SecurityGroups'][0]
+    except (KeyError, IndexError):
+        return None
+
+    return_obj = dict()
+
+    for field in ['Description', 'GroupName', 'IpPermissions', 'OwnerId', 'GroupId', 'IpPermissionsEgress', 'VpcId']:
+        try:
+            return_obj[field] = sg_data[field]
+        except KeyError:
+            pass
+
+    return return_obj

--- a/cloudaux/orchestration/aws/sg.md
+++ b/cloudaux/orchestration/aws/sg.md
@@ -1,0 +1,25 @@
+# CloudAux AWS Lambda Function
+
+CloudAux can build out a JSON object describing an AWS Security Group.
+
+## Example
+
+    from cloudaux.orchestration.aws.sg import describe_security_group
+
+    conn = dict(
+        account_number='111111111111',
+        assume_role='SecurityMonkey')
+
+    sg = describe_security_group('sg-12345678', **conn)
+    
+    print(json.dumps(provider, indent=2, sort_keys=True))
+
+    {
+      "Description": ...,
+      "GroupName": ...,
+      "IpPermissions" ...,
+      "OwnerId" ...,
+      "GroupId" ...,
+      "IpPermissionsEgress" ...,
+      "VpcId" ...
+    }

--- a/cloudaux/orchestration/aws/sg.py
+++ b/cloudaux/orchestration/aws/sg.py
@@ -1,0 +1,50 @@
+from cloudaux.aws.sg import describe_security_group
+from cloudaux.decorators import modify_output
+from cloudaux.orchestration.aws.arn import ARN
+from flagpole import FlagRegistry, Flags
+from six import string_types
+
+registry = FlagRegistry()
+FLAGS = Flags('BASE')
+
+
+@registry.register(flag=FLAGS.BASE)
+def _get_base(sg_obj, **conn):
+    base_fields = ['Description', 'GroupName', 'IpPermissions', 'OwnerId', 'GroupId', 'IpPermissionsEgress', 'VpcId']
+
+    if not all(field in sg_obj for field in base_fields):
+        sg_obj = describe_security_group(sg_obj['GroupId'], **conn)
+
+    sg_obj['_version'] = 1
+    return sg_obj
+
+
+@modify_output
+def get_security_group(sg_obj, flags=FLAGS.ALL, **conn):
+    """
+    Orchestrates calls to build a Security Group in the following format:
+
+    {
+        "Description": ...,
+        "GroupName": ...,
+        "IpPermissions" ...,
+        "OwnerId" ...,
+        "GroupId" ...,
+        "IpPermissionsEgress" ...,
+        "VpcId" ...
+    }
+    Args:
+        sg_obj: name, ARN, or dict of Security Group
+        flags: Flags describing which sections should be included in the return value. Default ALL
+
+    Returns:
+        dictionary describing the requested Security Group
+    """
+    if isinstance(sg_obj, string_types):
+        group_arn = ARN(sg_obj)
+        if group_arn.error:
+            sg_obj = {'GroupId': sg_obj}
+        else:
+            sg_obj = {'GroupId': group_arn.parsed_name}
+
+    return registry.build_out(flags, sg_obj, **conn)


### PR DESCRIPTION
This commit adds Security Groups to Cloudaux.  Supported commands
are:
 - list_security_groups
 - describe_security_group

Also orchestration:
 - get_security_group