### PR TITLE
Force client explicitly in get_role_managed_policy_documents

### DIFF
--- a/cloudaux/__about__.py
+++ b/cloudaux/__about__.py
@@ -13,7 +13,7 @@ __title__ = 'cloudaux'
 __summary__ = 'Cloud Auxiliary is a python wrapper and orchestration module for interacting with cloud providers'
 __uri__ = 'https://github.com/Netflix-Skunkworks/cloudaux'
 
-__version__ = '1.4.16'
+__version__ = '1.4.18'
 
 __author__ = 'Patrick Kelley'
 __email__ = 'patrick@netflix.com'

--- a/cloudaux/aws/iam.py
+++ b/cloudaux/aws/iam.py
@@ -167,10 +167,10 @@ def get_role_instance_profiles(role, client=None, **kwargs):
 @rate_limited()
 def get_role_managed_policy_documents(role, client=None, **kwargs):
     """Retrieve the currently active policy version document for every managed policy that is attached to the role."""
-    policies = get_role_managed_policies(role, **kwargs)
+    policies = get_role_managed_policies(role, force_client=client)
 
     policy_names = (policy['name'] for policy in policies)
-    delayed_gmpd_calls = (delayed(get_managed_policy_document)(policy['arn'], **kwargs) for policy in policies)
+    delayed_gmpd_calls = (delayed(get_managed_policy_document)(policy['arn'], force_client=client) for policy in policies)
     policy_documents = Parallel(n_jobs=20, backend="threading")(delayed_gmpd_calls)
 
     return dict(zip(policy_names, policy_documents))


### PR DESCRIPTION
Force client explicitly in cloudaux calls internal to get_role_managed_policy_documents.
Fixes #80 