### PR TITLE
Added ExternalId to sts.assume_role calls.

### DIFF
--- a/cloudaux/__about__.py
+++ b/cloudaux/__about__.py
@@ -14,7 +14,7 @@ __summary__ = 'Cloud Auxiliary is a python wrapper and orchestration module for 
 __uri__ = 'https://github.com/Netflix-Skunkworks/cloudaux'
 
 
-__version__ = '1.4.18'
+__version__ = '1.5.0'
 
 __author__ = 'The Cloudaux Developers'
 __email__ = 'oss@netflix.com'

--- a/cloudaux/decorators.py
+++ b/cloudaux/decorators.py
@@ -16,7 +16,7 @@ from cloudaux import CloudAux
 
 
 def iter_account_region(service, service_type='client', accounts=None, regions=None, assume_role=None,
-                        session_name='cloudaux', conn_type='cloudaux'):
+                        session_name='cloudaux', conn_type='cloudaux', external_id=None):
     def decorator(func):
         @functools.wraps(func)
         def decorated_function(*args, **kwargs):
@@ -28,7 +28,8 @@ def iter_account_region(service, service_type='client', accounts=None, regions=N
                     'region': region,
                     'session_name': session_name,
                     'assume_role': assume_role,
-                    'service_type': service_type
+                    'service_type': service_type,
+                    'external_id': external_id
                 }
                 if conn_type == 'cloudaux':
                     kwargs['cloudaux'] = CloudAux(**conn_dict)

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,8 @@ install_requires = [
 
 gcp_require = [
     'google-api-python-client>=1.6.1',
-    'google-cloud-storage==0.22.0'
+    'google-cloud-storage==0.22.0',
+    'oauth2client>=4.1.2'
 ]
 
 openstack_require = [


### PR DESCRIPTION
This PR adds an optional `ExternalId` to all `sts.assume_role` calls.

See https://github.com/Netflix/security_monkey/pull/1101 and https://github.com/Netflix/security_monkey/issues/1100.