### PR TITLE
Road to a more flexible gcp client generation

### DIFF
--- a/cloudaux/__about__.py
+++ b/cloudaux/__about__.py
@@ -13,7 +13,7 @@ __title__ = 'cloudaux'
 __summary__ = 'Cloud Auxiliary is a python wrapper and orchestration module for interacting with cloud providers'
 __uri__ = 'https://github.com/Netflix-Skunkworks/cloudaux'
 
-__version__ = '1.5.1'
+__version__ = '1.5.2'
 
 __author__ = 'The Cloudaux Developers'
 __email__ = 'oss@netflix.com'

--- a/cloudaux/gcp/auth.py
+++ b/cloudaux/gcp/auth.py
@@ -51,13 +51,13 @@ def get_client(service, service_type='client', **conn_args):
             client = get_google_client(
                 mod_name=client_details['module_name'],
                 key_file=conn_args.get('key_file', None),
-                user_agent=user_agent)
+                user_agent=user_agent, api_version=conn_args.get('api_version', 'v1'))
     else:
         # There is no client known for this service. We can try the standard API.
         try:
             client = get_google_client(
                 mod_name=service, key_file=conn_args.get('key_file', None),
-                user_agent=user_agent)
+                user_agent=user_agent, api_version=conn_args.get('api_version', 'v1'))
         except Exception as e:
             raise e
 

--- a/cloudaux/gcp/decorators.py
+++ b/cloudaux/gcp/decorators.py
@@ -36,7 +36,8 @@ def gcp_conn(service, service_type='client', future_expiration_minutes=15):
             client_details, client = get_client(
                 service, service_type=service_type,
                 future_expiration_minutes=15, **conn_args)
-            kwargs = rewrite_kwargs(client_details['client_type'], kwargs,
+            if client_details:
+                kwargs = rewrite_kwargs(client_details['client_type'], kwargs,
                                     client_details['module_name'])
             kwargs['client'] = client
             return f(*args, **kwargs)

--- a/cloudaux/gcp/utils.py
+++ b/cloudaux/gcp/utils.py
@@ -17,7 +17,8 @@ def get_creds_from_kwargs(kwargs):
         'key_file': kwargs.pop('key_file', None),
         'http_auth': kwargs.pop('http_auth', None),
         'project': kwargs.get('project', None),
-        'user_agent': kwargs.pop('user_agent', None)
+        'user_agent': kwargs.pop('user_agent', None),
+        'api_version': kwargs.pop('api_version', 'v1')
     }
     return (creds, kwargs)
 


### PR DESCRIPTION
We are extending security monkey for additional cloud services for example Cloud Sql, Big Query, ... thus we need a more flexible way to create gcp api clients. Currently our use case will be full filled if we could set he parameter **api_version**. This PR extends the gcp module exactly with this feature.