### PR TITLE
Added check if resp obj has 'items' in gce_list

### DIFF
--- a/cloudaux/__about__.py
+++ b/cloudaux/__about__.py
@@ -13,7 +13,7 @@ __title__ = 'cloudaux'
 __summary__ = 'Cloud Auxiliary is a python wrapper and orchestration module for interacting with cloud providers'
 __uri__ = 'https://github.com/Netflix-Skunkworks/cloudaux'
 
-__version__ = '1.5.4'
+__version__ = '1.5.5'
 
 __author__ = 'The Cloudaux Developers'
 __email__ = 'oss@netflix.com'

--- a/cloudaux/gcp/utils.py
+++ b/cloudaux/gcp/utils.py
@@ -84,11 +84,9 @@ def gce_list(service=None, **kwargs):
 
     while req is not None:
         resp = req.execute()
-        key_name = 'items'
-        if key_name in resp:
-            for item in resp[key_name]:
-                resp_list.append(item)
-            req = service.list_next(previous_request=req, previous_response=resp)
+        for item in resp.get('items', []):
+            resp_list.append(item)
+        req = service.list_next(previous_request=req, previous_response=resp)
     return resp_list
 
 

--- a/cloudaux/gcp/utils.py
+++ b/cloudaux/gcp/utils.py
@@ -84,9 +84,11 @@ def gce_list(service=None, **kwargs):
 
     while req is not None:
         resp = req.execute()
-        for item in resp['items']:
-            resp_list.append(item)
-        req = service.list_next(previous_request=req, previous_response=resp)
+        key_name = 'items'
+        if key_name in resp:
+            for item in resp[key_name]:
+                resp_list.append(item)
+            req = service.list_next(previous_request=req, previous_response=resp)
     return resp_list
 
 


### PR DESCRIPTION
For GCP projects which don't have firewalls rules a call to gce_list(service=client.firewalls(), **kwargs) would fail because resp does not contain the entry 'items'. This is for example the case for GCP management project like billing.