### PR TITLE
Fixing IAM Role to work with role_name or arn

### DIFF
--- a/cloudaux/__about__.py
+++ b/cloudaux/__about__.py
@@ -13,7 +13,7 @@ __title__ = 'cloudaux'
 __summary__ = 'Cloud Auxiliary is a python wrapper and orchestration module for interacting with cloud providers'
 __uri__ = 'https://github.com/Netflix-Skunkworks/cloudaux'
 
-__version__ = '1.5.7'
+__version__ = '1.5.8'
 
 __author__ = 'The Cloudaux Developers'
 __email__ = 'oss@netflix.com'

--- a/cloudaux/orchestration/aws/__init__.py
+++ b/cloudaux/orchestration/aws/__init__.py
@@ -1,6 +1,6 @@
 from cloudaux.orchestration.aws.arn import ARN
 from cloudaux.exceptions import CloudAuxException
-
+from cloudaux.orchestration.aws.iam import MissingFieldException
 
 def _conn_from_args(item, conn):
     if item.get('Arn'):
@@ -42,4 +42,4 @@ def _get_name_from_structure(item, default):
             raise CloudAuxException('Bad ARN: {arn}'.format(arn=arn))
         return item_arn.parsed_name
 
-    raise CloudAuxException('Cannot extract item name from input: {input}.'.format(input=item))
+    raise MissingFieldException('Cannot extract item name from input: {input}.'.format(input=item))

--- a/cloudaux/orchestration/aws/iam/managed_policy.py
+++ b/cloudaux/orchestration/aws/iam/managed_policy.py
@@ -11,7 +11,7 @@ from cloudaux.decorators import modify_output
 from flagpole import FlagRegistry, Flags
 
 from cloudaux.orchestration.aws import _conn_from_args
-from cloudaux.orchestration.aws.iam import MissingFieldException
+from cloudaux.orchestration.aws import _get_name_from_structure
 
 registry = FlagRegistry()
 FLAGS = Flags('BASE')
@@ -29,8 +29,9 @@ def get_base(managed_policy, **conn):
     """
     managed_policy['_version'] = 1
 
-    policy = get_policy(managed_policy['Arn'], **conn)
-    document = get_managed_policy_document(managed_policy['Arn'], policy_metadata=policy, **conn)
+    arn = _get_name_from_structure(managed_policy, 'Arn')
+    policy = get_policy(arn, **conn)
+    document = get_managed_policy_document(arn, policy_metadata=policy, **conn)
 
     managed_policy.update(policy['Policy'])
     managed_policy['Document'] = document
@@ -68,9 +69,5 @@ def get_managed_policy(managed_policy, flags=FLAGS.ALL, **conn):
     :param conn:
     :return:
     """
-    if not managed_policy.get('Arn'):
-        raise MissingFieldException('Must include Arn.')
-
     _conn_from_args(managed_policy, conn)
-
     return registry.build_out(flags, start_with=managed_policy, pass_datastructure=True, **conn)

--- a/cloudaux/orchestration/aws/iam/role.py
+++ b/cloudaux/orchestration/aws/iam/role.py
@@ -14,7 +14,6 @@ from cloudaux.orchestration import modify
 from cloudaux.decorators import modify_output
 from flagpole import FlagRegistry, Flags
 
-from cloudaux.orchestration.aws.iam import MissingFieldException
 
 registry = FlagRegistry()
 FLAGS = Flags('BASE', 'MANAGED_POLICIES', 'INLINE_POLICIES', 'INSTANCE_PROFILES')

--- a/cloudaux/orchestration/aws/iam/role.py
+++ b/cloudaux/orchestration/aws/iam/role.py
@@ -20,17 +20,17 @@ registry = FlagRegistry()
 FLAGS = Flags('BASE', 'MANAGED_POLICIES', 'INLINE_POLICIES', 'INSTANCE_PROFILES')
 
 
-@registry.register(flag=FLAGS.MANAGED_POLICIES, key='managed_policies')
+@registry.register(flag=FLAGS.MANAGED_POLICIES, depends_on=FLAGS.BASE, key='managed_policies')
 def get_managed_policies(role, **conn):
     return get_role_managed_policies(role, **conn)
 
 
-@registry.register(flag=FLAGS.INLINE_POLICIES, key='inline_policies')
+@registry.register(flag=FLAGS.INLINE_POLICIES, depends_on=FLAGS.BASE, key='inline_policies')
 def get_inline_policies(role, **conn):
     return get_role_inline_policies(role, **conn)
 
 
-@registry.register(flag=FLAGS.INSTANCE_PROFILES, key='instance_profiles')
+@registry.register(flag=FLAGS.INSTANCE_PROFILES, depends_on=FLAGS.BASE, key='instance_profiles')
 def get_instance_profiles(role, **conn):
     return get_role_instance_profiles(role, **conn)
 
@@ -88,9 +88,6 @@ def get_role(role, flags=FLAGS.ALL, **conn):
     Must at least have 'assume_role' key.
     :return: dict containing a fully built out role.
     """
-    if not role.get('RoleName'):
-        raise MissingFieldException('Must include RoleName.')
-
     role = modify(role, output='camelized')
     _conn_from_args(role, conn)
     return registry.build_out(flags, start_with=role, pass_datastructure=True, **conn)

--- a/cloudaux/orchestration/aws/iam/user.py
+++ b/cloudaux/orchestration/aws/iam/user.py
@@ -19,39 +19,38 @@ from cloudaux.orchestration import modify
 from cloudaux.decorators import modify_output
 from flagpole import FlagRegistry, Flags
 
-from cloudaux.orchestration.aws.iam import MissingFieldException
 
 registry = FlagRegistry()
 FLAGS = Flags('BASE', 'ACCESS_KEYS', 'INLINE_POLICIES', 'MANAGED_POLICIES', 'MFA_DEVICES', 'LOGIN_PROFILE',
               'SIGNING_CERTIFICATES')
 
 
-@registry.register(flag=FLAGS.ACCESS_KEYS, key='access_keys')
+@registry.register(flag=FLAGS.ACCESS_KEYS, depends_on=FLAGS.BASE, key='access_keys')
 def get_access_keys(user, **conn):
     return get_user_access_keys(user, **conn)
 
 
-@registry.register(flag=FLAGS.INLINE_POLICIES, key='inline_policies')
+@registry.register(flag=FLAGS.INLINE_POLICIES, depends_on=FLAGS.BASE, key='inline_policies')
 def get_inline_policies(user, **conn):
     return get_user_inline_policies(user, **conn)
 
 
-@registry.register(flag=FLAGS.MANAGED_POLICIES, key='managed_policies')
+@registry.register(flag=FLAGS.MANAGED_POLICIES, depends_on=FLAGS.BASE, key='managed_policies')
 def get_managed_policies(user, **conn):
     return get_user_managed_policies(user, **conn)
 
 
-@registry.register(flag=FLAGS.MFA_DEVICES, key='mfa_devices')
+@registry.register(flag=FLAGS.MFA_DEVICES, depends_on=FLAGS.BASE, key='mfa_devices')
 def get_mfa_devices(user, **conn):
     return get_user_mfa_devices(user, **conn)
 
 
-@registry.register(flag=FLAGS.LOGIN_PROFILE, key='login_profile')
+@registry.register(flag=FLAGS.LOGIN_PROFILE, depends_on=FLAGS.BASE, key='login_profile')
 def get_login_profile(user, **conn):
     return get_user_login_profile(user, **conn)
 
 
-@registry.register(flag=FLAGS.SIGNING_CERTIFICATES, key='signing_certificates')
+@registry.register(flag=FLAGS.SIGNING_CERTIFICATES, depends_on=FLAGS.BASE, key='signing_certificates')
 def get_signing_certificates(user, **conn):
     return get_user_signing_certificates(user, **conn)
 
@@ -103,9 +102,6 @@ def get_user(user, flags=FLAGS.ALL, **conn):
     Must at least have 'assume_role' key.
     :return: dict containing fully built out user.
     """
-    if not user.get('UserName'):
-        raise MissingFieldException('Must include UserName.')
-
     user = modify(user, output='camelized')
     _conn_from_args(user, conn)
     return registry.build_out(flags, start_with=user, pass_datastructure=True, **conn)

--- a/cloudaux/tests/aws/test_iam.py
+++ b/cloudaux/tests/aws/test_iam.py
@@ -147,9 +147,10 @@ def test_list_groups_for_user(group_fixture):
 def test_get_role_orchestration(test_iam):
     """Tests the get_group orchestration."""
     from cloudaux.orchestration.aws.iam.role import get_role
+    from cloudaux.exceptions import CloudAuxException
 
     # Don't pass in the RoleName:
-    with pytest.raises(MissingFieldException, message='Must include RoleName.'):
+    with pytest.raises(CloudAuxException, message='Cannot extract item name from input: {}'):
         get_role({}, force_client=test_iam)
 
     result = get_role({'RoleName': 'testRoleCloudAuxName'}, force_client=test_iam)

--- a/cloudaux/tests/aws/test_iam.py
+++ b/cloudaux/tests/aws/test_iam.py
@@ -147,10 +147,9 @@ def test_list_groups_for_user(group_fixture):
 def test_get_role_orchestration(test_iam):
     """Tests the get_group orchestration."""
     from cloudaux.orchestration.aws.iam.role import get_role
-    from cloudaux.exceptions import CloudAuxException
 
     # Don't pass in the RoleName:
-    with pytest.raises(CloudAuxException, message='Cannot extract item name from input: {}'):
+    with pytest.raises(MissingFieldException, message='Cannot extract item name from input: {}'):
         get_role({}, force_client=test_iam)
 
     result = get_role({'RoleName': 'testRoleCloudAuxName'}, force_client=test_iam)
@@ -192,7 +191,7 @@ def test_get_user_orchestration(test_iam):
     from cloudaux.orchestration.aws.iam.user import get_user
 
     # Don't pass in the RoleName:
-    with pytest.raises(MissingFieldException, message='Must include UserName.'):
+    with pytest.raises(MissingFieldException, message='Cannot extract item name from input: {}'):
         get_user({}, force_client=test_iam)
 
     result = get_user({'UserName': 'testCloudAuxUser'}, force_client=test_iam)


### PR DESCRIPTION
Updating IAM Role Orchestration and tests to always call base first to ensure a RoleName or ARN are passed in.