### PR TITLE
Allow sts assume role in 'AWS GovCloud' partition

### DIFF
--- a/cloudaux/__about__.py
+++ b/cloudaux/__about__.py
@@ -13,7 +13,7 @@ __title__ = 'cloudaux'
 __summary__ = 'Cloud Auxiliary is a python wrapper and orchestration module for interacting with cloud providers'
 __uri__ = 'https://github.com/Netflix-Skunkworks/cloudaux'
 
-__version__ = '1.5.8'
+__version__ = '1.5.9'
 
 __author__ = 'The Cloudaux Developers'
 __email__ = 'oss@netflix.com'

--- a/cloudaux/decorators.py
+++ b/cloudaux/decorators.py
@@ -16,7 +16,7 @@ from cloudaux import CloudAux
 
 
 def iter_account_region(service, service_type='client', accounts=None, regions=None, assume_role=None,
-                        session_name='cloudaux', conn_type='cloudaux', external_id=None):
+                        session_name='cloudaux', conn_type='cloudaux', external_id=None, arn_partition='aws'):
     def decorator(func):
         @functools.wraps(func)
         def decorated_function(*args, **kwargs):
@@ -29,7 +29,8 @@ def iter_account_region(service, service_type='client', accounts=None, regions=N
                     'session_name': session_name,
                     'assume_role': assume_role,
                     'service_type': service_type,
-                    'external_id': external_id
+                    'external_id': external_id,
+                    'arn_partition': arn_partition
                 }
                 if conn_type == 'cloudaux':
                     kwargs['cloudaux'] = CloudAux(**conn_dict)

--- a/cloudaux/orchestration/aws/s3.py
+++ b/cloudaux/orchestration/aws/s3.py
@@ -225,7 +225,13 @@ def get_notifications(bucket_name, **conn):
 
 @registry.register(flag=FLAGS.ACCELERATION, key='acceleration')
 def get_acceleration(bucket_name, **conn):
-    result = get_bucket_accelerate_configuration(Bucket=bucket_name, **conn)
+    try:
+        result = get_bucket_accelerate_configuration(Bucket=bucket_name, **conn)
+    except ClientError as e:
+        if "UnsupportedArgument" not in str(e):
+            # UnsupportedArgument exception is raised in aws-us-gov partition
+            raise e
+        return None
     return result.get("Status")
 
 

--- a/cloudaux/tests/aws/test_arn.py
+++ b/cloudaux/tests/aws/test_arn.py
@@ -15,6 +15,7 @@ def test_arn():
 
     arn = ARN(test_arn)
 
+    assert arn.partition == 'aws'
     assert arn.tech == 'iam'
     assert arn.region == ''
     assert arn.account_number == '123456789123'
@@ -26,6 +27,20 @@ def test_arn():
 
     arn = ARN(test_arn2)
 
+    assert arn.partition == 'aws'
+    assert arn.tech == 'iam'
+    assert arn.region == ''
+    assert arn.account_number == '123456789123'
+    assert arn.name == 'role/service-role/DynamoDBAutoscaleRole'
+    assert arn.resource_type == 'role'
+    assert arn.resource == 'service-role/DynamoDBAutoscaleRole'
+
+    # Test for GovCloud Partition
+    test_arn3 = 'arn:aws-us-gov:iam::123456789123:role/service-role/DynamoDBAutoscaleRole'
+
+    arn = ARN(test_arn3)
+
+    assert arn.partition == 'aws-us-gov'
     assert arn.tech == 'iam'
     assert arn.region == ''
     assert arn.account_number == '123456789123'


### PR DESCRIPTION
Fixes#93. This fix will allow user to run sts assume role on other **aws** partitions such as _aws-us-gov_ by passing an optional parameter _arn_partition_ to `boto3_cached_conn` function or `iter_account_region` decorator calls.

This also addresses `UnsupportedArgument` exception raised by `flagpole` -> `get_acceleration` function in _aws-us-gov_ partition for lack of **S3 Acceleration service**.

https://github.com/Netflix-Skunkworks/cloudaux/blob/ace3daf4ce4205a275fe3f7fa119fc4affc6f5c2/cloudaux/orchestration/aws/s3.py#L227


