### PR TITLE
Adding desc content type.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,6 +76,7 @@ setup(
     url=about["__uri__"],
     description=about["__summary__"],
     long_description=open(os.path.join(ROOT, 'README.md')).read(),
+    long_description_content_type="text/markdown",
     packages=find_packages(),
     include_package_data=True,
     zip_safe=False,


### PR DESCRIPTION
Adding section long_description_content_type to setup.py to fix these errors:

`HTTPError: 400 Client Error: The description failed to render in the default format of reStructuredText.`

After merging to master, I think we can use these to upload to pypi:

```
$ pip install --upgrade setuptools wheel twine
$ python setup.py sdist
$ python setup.py bdist_wheel
$ twine upload dist/*whl dist/*gz
```