### PR TITLE
Additional Cloudaux resources for GCP.

### DIFF
--- a/cloudaux/__about__.py
+++ b/cloudaux/__about__.py
@@ -13,10 +13,10 @@ __title__ = 'cloudaux'
 __summary__ = 'Cloud Auxiliary is a python wrapper and orchestration module for interacting with cloud providers'
 __uri__ = 'https://github.com/Netflix-Skunkworks/cloudaux'
 
-__version__ = '1.6.4'
+__version__ = '1.6.5'
 
 __author__ = 'The Cloudaux Developers'
 __email__ = 'oss@netflix.com'
 
 __license__ = 'Apache License, Version 2.0'
-__copyright__ = 'Copyright 2018 %s' % __author__
+__copyright__ = 'Copyright 2019 %s' % __author__

--- a/cloudaux/gcp/config.py
+++ b/cloudaux/gcp/config.py
@@ -22,5 +22,7 @@ GOOGLE_CLIENT_MAP = {
     'gce':
     {'client_type': 'general', 'module_name': 'compute'},
     'iam':
-    {'client_type': 'general', 'module_name': 'iam'}
+    {'client_type': 'general', 'module_name': 'iam'},
+    'crm':
+    {'client_type': 'general', 'module_name': 'cloudresourcemanager'},
 }

--- a/cloudaux/gcp/crm.py
+++ b/cloudaux/gcp/crm.py
@@ -1,0 +1,17 @@
+"""
+.. module: cloudaux.gcp.crm
+    :platform: Unix
+    :copyright: (c) 2019 by Fitbit Inc., see AUTHORS for more
+    :license: Apache, see LICENSE for more details.
+.. moduleauthor:: Greg Harris <gharris@fitbit.com>
+"""
+from cloudaux.gcp.utils import service_list
+from cloudaux.gcp.decorators import gcp_conn, gcp_stats
+from cloudaux.gcp.utils import service_list
+
+
+@gcp_conn('crm')
+def get_iam_policy(client=None, **kwargs):
+    req = client.projects().getIamPolicy(resource=kwargs['resource'])
+    return req.execute()
+

--- a/cloudaux/gcp/crm.py
+++ b/cloudaux/gcp/crm.py
@@ -12,6 +12,7 @@ from cloudaux.gcp.utils import service_list
 
 @gcp_conn('crm')
 def get_iam_policy(client=None, **kwargs):
-    req = client.projects().getIamPolicy(resource=kwargs['resource'])
+    # body={} workaround for https://github.com/googleapis/google-api-python-client/issues/713
+    req = client.projects().getIamPolicy(resource=kwargs['resource'], body={})
     return req.execute()
 

--- a/cloudaux/gcp/gce/address.py
+++ b/cloudaux/gcp/gce/address.py
@@ -1,0 +1,43 @@
+"""
+.. module: cloudaux.gcp.gce.address
+    :platform: Unix
+    :copyright: (c) 2019 by Fitbit Inc., see AUTHORS for more
+    :license: Apache, see LICENSE for more details.
+.. moduleauthor:: Greg Harris <gharris@fitbit.com>
+"""
+from cloudaux.gcp.utils import gce_list, gce_list_aggregated
+from cloudaux.gcp.decorators import gcp_conn
+
+@gcp_conn('gce')
+def list_addresses(client=None, **kwargs):
+    """
+    :rtype: ``list``
+    """
+
+    return gce_list_aggregated(service=client.addresses(), **kwargs)
+
+
+@gcp_conn('gce')
+def list_global_addresses(client=None, **kwargs):
+    """
+    :rtype: ``list``
+    """
+
+    return gce_list(service=client.globalAddresses(), **kwargs)
+
+
+@gcp_conn('gce')
+def get_address(client=None, **kwargs):
+    service = client.addresses()
+    req = service.get(project=kwargs['project'],
+                      address=kwargs['Address'],
+                      region=kwargs['Region'])
+    return req.execute()
+
+
+@gcp_conn('gce')
+def get_global_address(client=None, **kwargs):
+    service = client.globalAddresses()
+    req = service.get(project=kwargs['project'],
+                      address=kwargs['GlobalAddress'])
+    return req.execute()

--- a/cloudaux/gcp/gce/disk.py
+++ b/cloudaux/gcp/gce/disk.py
@@ -1,0 +1,24 @@
+"""
+.. module: cloudaux.gcp.gce.disk
+    :platform: Unix
+    :copyright: (c) 2019 by Fitbit Inc., see AUTHORS for more
+    :license: Apache, see LCIENSE for more details.
+.. moduleauthor:: Greg Harris <gharris@fitbit.com>
+"""
+from cloudaux.gcp.utils import gce_list
+from cloudaux.gcp.decorators import gcp_conn
+
+@gcp_conn('gce')
+def list_disks(client=None, **kwargs):
+    """
+    :rtype: ``list``
+    """
+    return gce_list(service=client.disks(),
+                        **kwargs)
+
+@gcp_conn('gce')
+def get_disk(client=None, **kwargs):
+    service = client.disks()
+    req = service.get(project=kwargs['project'], name=kwargs['disk'])
+    resp = req.execute()
+    return resp

--- a/cloudaux/gcp/gce/forwarding_rule.py
+++ b/cloudaux/gcp/gce/forwarding_rule.py
@@ -1,0 +1,44 @@
+"""
+.. module: cloudaux.gcp.gce.forwarding_rule
+    :platform: Unix
+    :copyright: (c) 2019 by Fitbit Inc., see AUTHORS for more
+    :license: Apache, see LICENSE for more details.
+.. moduleauthor:: Greg Harris <gharris@fitbit.com>
+"""
+from cloudaux.gcp.utils import gce_list, gce_list_aggregated
+from cloudaux.gcp.decorators import gcp_conn
+
+
+@gcp_conn('gce')
+def list_forwarding_rules(client=None, **kwargs):
+    """
+    :rtype: ``list``
+    """
+
+    return gce_list_aggregated(service=client.forwardingRules(), **kwargs)
+
+
+@gcp_conn('gce')
+def list_global_forwarding_rules(client=None, **kwargs):
+    """
+    :rtype: ``list``
+    """
+
+    return gce_list(service=client.globalForwardingRules(), **kwargs)
+
+
+@gcp_conn('gce')
+def get_forwarding_rule(client=None, **kwargs):
+    service = client.forwardingRules()
+    req = service.get(project=kwargs['project'],
+                      forwardingRule=kwargs['ForwardingRule'],
+                      region=kwargs['Region'])
+    return req.execute()
+
+
+@gcp_conn('gce')
+def get_global_forwarding_rule(client=None, **kwargs):
+    service = client.globalForwardingRules()
+    req = service.get(project=kwargs['project'],
+                      forwardingRule=kwargs['GlobalForwardingRule'])
+    return req.execute()

--- a/cloudaux/gcp/gce/instance.py
+++ b/cloudaux/gcp/gce/instance.py
@@ -1,0 +1,24 @@
+"""
+.. module: cloudaux.gcp.gce.instance
+    :platform: Unix
+    :copyright: (c) 2019 by Fitbit Inc., see AUTHORS for more
+    :license: Apache, see LCIENSE for more details.
+.. moduleauthor:: Greg Harris <gharris@fitbit.com>
+"""
+from cloudaux.gcp.utils import gce_list
+from cloudaux.gcp.decorators import gcp_conn
+
+@gcp_conn('gce')
+def list_instances(client=None, **kwargs):
+    """
+    :rtype: ``list``
+    """
+    return gce_list(service=client.instances(),
+                        **kwargs)
+
+@gcp_conn('gce')
+def get_instance(client=None, **kwargs):
+    service = client.instances()
+    req = service.get(project=kwargs['project'], name=kwargs['instance'])
+    resp = req.execute()
+    return resp

--- a/cloudaux/gcp/gce/network.py
+++ b/cloudaux/gcp/gce/network.py
@@ -16,6 +16,7 @@ def list_networks(client=None, **kwargs):
     return gce_list(service=client.networks(),
                         **kwargs)
 
+
 @gcp_conn('gce')
 def list_subnetworks(client=None, **kwargs):
     """
@@ -25,12 +26,14 @@ def list_subnetworks(client=None, **kwargs):
     return gce_list_aggregated(service=client.subnetworks(),
                                    key_name='subnetworks', **kwargs)
 
+
 @gcp_conn('gce')
 def get_network(client=None, **kwargs):
     service = client.networks()
     req = service.get(project=kwargs['project'], network=kwargs['Network'])
     resp = req.execute()
     return resp
+
 
 @gcp_conn('gce')
 def get_subnetwork(client=None, **kwargs):

--- a/cloudaux/gcp/gce/project.py
+++ b/cloudaux/gcp/gce/project.py
@@ -1,0 +1,16 @@
+"""
+.. module: cloudaux.gcp.gce.project
+    :platform: Unix
+    :copyright: (c) 2019 by Fitbit Inc., see AUTHORS for more
+    :license: Apache, see LICENSE for more details.
+.. moduleauthor:: Greg Harris <gharris@fitbit.com>
+"""
+from cloudaux.gcp.utils import service_list
+from cloudaux.gcp.decorators import gcp_conn, gcp_stats
+from cloudaux.gcp.utils import service_list
+
+@gcp_conn('gce')
+def get_project(client=None, **kwargs):
+    req = client.projects().get(project=kwargs['project'])
+    resp = req.execute()
+    return resp

--- a/cloudaux/gcp/gce/zone.py
+++ b/cloudaux/gcp/gce/zone.py
@@ -1,0 +1,24 @@
+"""
+.. module: cloudaux.gcp.gce.zone
+    :platform: Unix
+    :copyright: (c) 2019 by Fitbit Inc., see AUTHORS for more
+    :license: Apache, see LCIENSE for more details.
+.. moduleauthor:: Greg Harris <gharris@fitbit.com>
+"""
+from cloudaux.gcp.utils import gce_list
+from cloudaux.gcp.decorators import gcp_conn
+
+@gcp_conn('gce')
+def list_zones(client=None, **kwargs):
+    """
+    :rtype: ``list``
+    """
+    return gce_list(service=client.zones(),
+                        **kwargs)
+
+@gcp_conn('gce')
+def get_zone(client=None, **kwargs):
+    service = client.zones()
+    req = service.get(project=kwargs['project'], name=kwargs['zone'])
+    resp = req.execute()
+    return resp

--- a/cloudaux/gcp/iam.py
+++ b/cloudaux/gcp/iam.py
@@ -45,3 +45,9 @@ def get_iam_policy(client=None, **kwargs):
         return resp['bindings']
     else:
         return None
+
+@gcp_conn('crm')
+def get_project_iam_policy(client=None, **kwargs):
+    print(kwargs)
+    req = client.projects().getIamPolicy(resource=kwargs['resource'])
+    return req.execute()

--- a/cloudaux/gcp/iam.py
+++ b/cloudaux/gcp/iam.py
@@ -48,6 +48,6 @@ def get_iam_policy(client=None, **kwargs):
 
 @gcp_conn('crm')
 def get_project_iam_policy(client=None, **kwargs):
-    print(kwargs)
-    req = client.projects().getIamPolicy(resource=kwargs['resource'])
+    # body={} is a workaround for a bug in older version of the google libraries
+    req = client.projects().getIamPolicy(resource=kwargs['resource'], body={})
     return req.execute()

--- a/cloudaux/tests/gcp/test_integration.py
+++ b/cloudaux/tests/gcp/test_integration.py
@@ -1,0 +1,58 @@
+import pytest
+import os
+
+from cloudaux.gcp.iam import get_project_iam_policy
+from cloudaux.gcp.gce.project import get_project
+from cloudaux.gcp.crm import get_iam_policy
+from cloudaux.gcp.gce.address import (
+    list_addresses,
+    list_global_addresses,
+)
+from cloudaux.gcp.gce.disk import (
+    list_disks,
+)
+from cloudaux.gcp.gce.forwarding_rule import (
+    list_forwarding_rules,
+    list_global_forwarding_rules,
+)
+from cloudaux.gcp.gce.instance import (
+    list_instances
+)
+from cloudaux.gcp.gce.zone import (
+    list_zones
+)
+
+@pytest.fixture
+def project():
+    return os.getenv('CLOUDAUX_GCP_TEST_PROJECT')
+
+@pytest.mark.skipif(
+    os.getenv('CLOUDAUX_GCP_TEST_PROJECT') is None,
+    reason="Cannot run integration tests unless GCP project configured"
+)
+@pytest.mark.parametrize('function,p_param', [
+    (list_addresses, 'project'),
+    (list_forwarding_rules, 'project'),
+    (list_global_addresses, 'project'),
+    (list_global_forwarding_rules, 'project'),
+    (get_iam_policy, 'resource'),
+    (get_project, 'project'),
+    (get_project_iam_policy, 'resource'),
+])
+def test_cloudaux_gcp_global_integration(function, p_param, project):
+    result = function(**{p_param: project})
+    assert result is not None
+
+@pytest.mark.skipif(
+    os.getenv('CLOUDAUX_GCP_TEST_PROJECT') is None,
+    reason="Cannot run integration tests unless GCP project configured"
+)
+@pytest.mark.parametrize('function,p_param,z_param', [
+    (list_disks, 'project', 'zone'),
+    (list_instances, 'project', 'zone'),
+])
+def test_cloudaux_gcp_zoned_integration(function, p_param, z_param, project):
+    for zone in list_zones(project=project):
+        result = function(**{p_param: project, z_param: zone['name']})
+        assert result is not None
+

--- a/cloudaux/tests/gcp/test_integration.py
+++ b/cloudaux/tests/gcp/test_integration.py
@@ -1,6 +1,10 @@
 import pytest
 import os
 
+from cloudaux.gcp.gcs import (
+    list_buckets,
+    list_objects_in_bucket,
+)
 from cloudaux.gcp.iam import get_project_iam_policy
 from cloudaux.gcp.gce.project import get_project
 from cloudaux.gcp.crm import get_iam_policy
@@ -56,3 +60,11 @@ def test_cloudaux_gcp_zoned_integration(function, p_param, z_param, project):
         result = function(**{p_param: project, z_param: zone['name']})
         assert result is not None
 
+@pytest.mark.skipif(
+    os.getenv('CLOUDAUX_GCP_TEST_PROJECT') is None,
+    reason="Cannot run integration tests unless GCP project configured"
+)
+def test_cloudaux_gcs(project):
+    for bucket in list_buckets(project=project):
+        for bucket_object in list_objects_in_bucket(Bucket=bucket['name']):
+            assert bucket_object is not None

--- a/cloudaux/tests/gcp/test_utils.py
+++ b/cloudaux/tests/gcp/test_utils.py
@@ -17,6 +17,7 @@ class TestUtils(unittest.TestCase):
                 'foo': 'bar',
                 'user_agent': 'cloudaux'}
         expected_creds = {
+            'api_version': 'v1',
             'project': 'my-project',
             'key_file': '/path/to/myfile.json',
             'http_auth': None,

--- a/setup.py
+++ b/setup.py
@@ -45,10 +45,9 @@ install_requires = [
 ]
 
 gcp_require = [
-    'google-api-python-client>=1.7.9',
-    'google-cloud-storage==1.16.1',
-    'oauth2client>=4.1.2',
-    'httplib2>=0.13.0'
+    'google-api-python-client>=1.6.1',
+    'google-cloud-storage==0.22.0',
+    'oauth2client>=4.1.2'
 ]
 
 openstack_require = [

--- a/setup.py
+++ b/setup.py
@@ -45,9 +45,10 @@ install_requires = [
 ]
 
 gcp_require = [
-    'google-api-python-client>=1.6.1',
-    'google-cloud-storage==0.22.0',
-    'oauth2client>=4.1.2'
+    'google-api-python-client>=1.7.9',
+    'google-cloud-storage==1.16.1',
+    'oauth2client>=4.1.2',
+    'httplib2>=0.13.0'
 ]
 
 openstack_require = [

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,7 @@ deps =
     .[openstack]
 
 commands =
-    pytest {posargs} --cov=cloudaux cloudaux/tests/aws cloudaux/tests/openstack
+    pytest {posargs} --cov=cloudaux cloudaux/tests/aws cloudaux/tests/openstack cloudaux/tests/gcp
 ;    flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
 ;    flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 


### PR DESCRIPTION
Fitbit has been using Security Monkey internally to monitor GCP
environments and we'd like to start contributing back some of that code
to the main Security Monkey project.

This PR contains the following:
 * Support for GCE Instances
 * Support for GCE Persistent Disks
 * Support for GCE Addresses (global and regional)
 * Support for GCE Forwarding Rules (global and regional)
 * Support for CRM (i.e., Google Projects and their related IAM policy bindings)

I've also modified the `tox.ini` to enable the GCP tests which were
previously added but not hooked up to the CI.  In the process I've fixed
a broken GCP test. The tox tests for python3 are failing but should be 
resolved when my other pull request is merged.

This is a pre-requisite for Security Monkey watcher and auditor support
for these resource types.

@mikegrima, the Security Monkey changes we've done on top of this would require us to bump the cloudaux version so they can depend on a version with these resources.  Is this something I should request as part of this pull request?  Thanks!