### PR TITLE
Missing comma in lambda orchestrator

### DIFF
--- a/cloudaux/__about__.py
+++ b/cloudaux/__about__.py
@@ -13,7 +13,7 @@ __title__ = 'cloudaux'
 __summary__ = 'Cloud Auxiliary is a python wrapper and orchestration module for interacting with cloud providers'
 __uri__ = 'https://github.com/Netflix-Skunkworks/cloudaux'
 
-__version__ = '1.7.0'
+__version__ = '1.7.1'
 
 __author__ = 'The Cloudaux Developers'
 __email__ = 'oss@netflix.com'

--- a/cloudaux/orchestration/aws/lambda_function.py
+++ b/cloudaux/orchestration/aws/lambda_function.py
@@ -72,7 +72,7 @@ def _get_event_source_mappings(lambda_function, **conn):
 @registry.register(flag=FLAGS.BASE)
 def get_base(lambda_function, **conn):
     base_fields = frozenset(
-        ['FunctionName', 'FunctionArn', 'Runtime', 'Role', 'Handler'
+        ['FunctionName', 'FunctionArn', 'Runtime', 'Role', 'Handler',
         'CodeSize', 'Description', 'Timeout', 'MemorySize', 'LastModified',
         'CodeSha256', 'Version', 'VpcConfig', 'DeadLetterConfig', 'Environment',
         'KMSKeyArn', 'TracingConfig', 'MasterArn'])


### PR DESCRIPTION
Semmle found a bug in the lambda code:

https://lgtm.com/projects/g/Netflix-Skunkworks/cloudaux/?mode=list&tag=external%2Fcwe%2Fcwe-665

> Implicit string concatenation. Maybe missing a comma?