### PR TITLE
Fixes Issue #110. make conn_details instance variable.

### DIFF
--- a/cloudaux/__about__.py
+++ b/cloudaux/__about__.py
@@ -13,7 +13,7 @@ __title__ = 'cloudaux'
 __summary__ = 'Cloud Auxiliary is a python wrapper and orchestration module for interacting with cloud providers'
 __uri__ = 'https://github.com/Netflix-Skunkworks/cloudaux'
 
-__version__ = '1.7.0'
+__version__ = '1.7.2'
 
 __author__ = 'The Cloudaux Developers'
 __email__ = 'oss@netflix.com'

--- a/cloudaux/__init__.py
+++ b/cloudaux/__init__.py
@@ -2,10 +2,6 @@ from cloudaux.aws.sts import sts_conn
 
 
 class CloudAux:
-    conn_details = {
-        'session_name': 'cloudaux',
-        'region': 'us-east-1'
-    }
 
     def __init__(self, **kwargs):
         """
@@ -14,6 +10,10 @@ class CloudAux:
                'assume_role': 'role_name',
             })
         """
+        self.conn_details = {
+            'session_name': 'cloudaux',
+            'region': 'us-east-1'
+        }
         self.conn_details.update(kwargs)
 
     def call(self, function_expr, **kwargs):

--- a/cloudaux/tests/cloudaux/test_cloudaux.py
+++ b/cloudaux/tests/cloudaux/test_cloudaux.py
@@ -1,0 +1,37 @@
+"""
+.. module: cloudaux.tests.cloudaux.test_cloudaux
+    :platform: Unix
+    :copyright: (c) 2019 by Netflix Inc., see AUTHORS for more
+    :license: Apache, see LICENSE for more details.
+.. moduleauthor:: Patrick Kelley <patrickk@23andme.com>
+"""
+from cloudaux import CloudAux
+
+
+def test_cloudaux():
+    conn_one = {
+        "account_number": "111111111111",
+        "assume_role": "role_one",
+        "region": "us-east-1",
+        "session_name": "conn_one"
+    }
+
+    conn_two = {
+        "account_number": "222222222222",
+        "assume_role": "role_two",
+        "region": "us-east-2",
+        "session_name": "conn_two"
+    }
+
+    ca_one = CloudAux(**conn_one)
+    ca_two = CloudAux(**conn_two)
+
+    assert ca_one.conn_details["account_number"] == "111111111111"
+    assert ca_one.conn_details["assume_role"] == "role_one"
+    assert ca_one.conn_details["region"] == "us-east-1"
+    assert ca_one.conn_details["session_name"] == "conn_one"
+
+    assert ca_two.conn_details["account_number"] == "222222222222"
+    assert ca_two.conn_details["assume_role"] == "role_two"
+    assert ca_two.conn_details["region"] == "us-east-2"
+    assert ca_two.conn_details["session_name"] == "conn_two"

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,7 @@ deps =
     .[openstack]
 
 commands =
-    pytest {posargs} --cov=cloudaux cloudaux/tests/aws cloudaux/tests/openstack cloudaux/tests/gcp
+    pytest {posargs} --cov=cloudaux cloudaux/tests/cloudaux cloudaux/tests/aws cloudaux/tests/openstack cloudaux/tests/gcp
 ;    flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
 ;    flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 


### PR DESCRIPTION
The CloudAux class had a class variable called conn_details.
If you instantiated two CloudAux objects, the conn_details would be overwritten.
This PR moves conn_details to be an instance variable.

See #110 