### PR TITLE
Allow custom configuration for cached connection

### DIFF
--- a/cloudaux/__about__.py
+++ b/cloudaux/__about__.py
@@ -13,10 +13,10 @@ __title__ = 'cloudaux'
 __summary__ = 'Cloud Auxiliary is a python wrapper and orchestration module for interacting with cloud providers'
 __uri__ = 'https://github.com/Netflix-Skunkworks/cloudaux'
 
-__version__ = '1.8.1'
+__version__ = '1.8.2'
 
 __author__ = 'The Cloudaux Developers'
 __email__ = 'oss@netflix.com'
 
 __license__ = 'Apache License, Version 2.0'
-__copyright__ = 'Copyright 2019 %s' % __author__
+__copyright__ = 'Copyright 2020 %s' % __author__

--- a/cloudaux/tests/aws/test_sts.py
+++ b/cloudaux/tests/aws/test_sts.py
@@ -5,8 +5,9 @@
     :license: Apache, see LICENSE for more details.
 .. moduleauthor:: Josafat Gonzalez <josafatg@netflix.com>
 """
-from mock import patch
+from botocore.client import Config
 from cloudaux.aws.sts import boto3_cached_conn
+from mock import patch
 
 
 def test_boto3_cached_conn_read_only():
@@ -82,4 +83,31 @@ def test_boto3_cached_conn_retry_config(sts):
     with patch('cloudaux.aws.sts._client', mock_client):
         conn = boto3_cached_conn('s3', **conn_details)
         assert conn.mock_calls[1].kwargs['config'].retries == {'max_attempts': 1000}
+        cloudaux.aws.sts.CACHE = {}
+
+def test_boto3_cached_conn_config(sts):
+    from cloudaux.aws.sts import _client
+    import cloudaux.aws.sts
+
+    def mock_client(*args, **kwargs):
+        with patch('boto3.session.Session') as p:
+            _client(*args, **kwargs)
+
+        return p
+
+    # With the default:
+    with patch('cloudaux.aws.sts._client', mock_client):
+        conn = boto3_cached_conn('s3', config=Config(signature_version='s3v4'))
+        assert conn.mock_calls[1].kwargs['config'].signature_version == 's3v4'
+        cloudaux.aws.sts.CACHE = {}
+
+    # With STS role assumption:
+    conn_details = {
+        'account_number': '111111111111',
+        'assume_role': 'role_one',
+        'region': 'us-east-1'
+    }
+    with patch('cloudaux.aws.sts._client', mock_client):
+        conn = boto3_cached_conn('s3', config=Config(signature_version='s3v4'), **conn_details)
+        assert conn.mock_calls[1].kwargs['config'].signature_version == 's3v4'
         cloudaux.aws.sts.CACHE = {}


### PR DESCRIPTION
This PR adds a `config` keyword argument to `boto3_cached_conn()` that allows end users to specify a `botocore.client.Config` to be passed to the boto3 client creation. This enables a workaround for boto/botocore#2109 by setting the `config` argument in the `sts_conn()` decorator:

```python
@sts_conn('s3', config=Config(signature_version='s3v4'))
```