### PR TITLE
Fix orchestration.group.get_inline_policies

### DIFF
--- a/cloudaux/__about__.py
+++ b/cloudaux/__about__.py
@@ -13,7 +13,7 @@ __title__ = 'cloudaux'
 __summary__ = 'Cloud Auxiliary is a python wrapper and orchestration module for interacting with cloud providers'
 __uri__ = 'https://github.com/Netflix-Skunkworks/cloudaux'
 
-__version__ = '1.8.2'
+__version__ = '1.8.3'
 
 __author__ = 'The Cloudaux Developers'
 __email__ = 'oss@netflix.com'

--- a/cloudaux/orchestration/aws/iam/group.py
+++ b/cloudaux/orchestration/aws/iam/group.py
@@ -22,7 +22,7 @@ FLAGS = Flags('BASE', 'INLINE_POLICIES', 'MANAGED_POLICIES', 'USERS')
 @registry.register(flag=FLAGS.INLINE_POLICIES, key='inline_policies')
 def get_inline_policies(group, **conn):
     """Get the inline policies for the group."""
-    policy_list = list_group_policies(group['GroupName'])
+    policy_list = list_group_policies(group['GroupName'], **conn)
 
     policy_documents = {}
 


### PR DESCRIPTION
The orchestration function `get_inline_policies` didn't pass connection parameters to `list_group_policies`. Making the flag `INLINE_POLICIES` unusable.
With this PR, the connection parameters are passed.