### PR TITLE
Fix AWS pagination for responses with empty results

### DIFF
--- a/cloudaux/aws/decorators.py
+++ b/cloudaux/aws/decorators.py
@@ -67,10 +67,10 @@ def paginated(response_key, request_pagination_marker="Marker", response_paginat
                 response = func(*args, **kwargs)
                 results.extend(response[response_key])
 
-                # If the response contained results, and the "next" pagination marker is in the response, then paginate.
-                if response[response_key] and response.get(response_pagination_marker):
+                # If the "next" pagination marker is in the response, then paginate. Responses may not always have
+                # items in the response_key, so we should only key off of the response_pagination_marker.
+                if response.get(response_pagination_marker):
                     kwargs.update({request_pagination_marker: response[response_pagination_marker]})
-
                 else:
                     break
             return results

--- a/cloudaux/tests/aws/test_decorators.py
+++ b/cloudaux/tests/aws/test_decorators.py
@@ -1,0 +1,88 @@
+"""
+.. module: cloudaux.tests.aws.test_decorators
+    :platform: Unix
+    :copyright: (c) 2021 by Netflix Inc., see AUTHORS for more
+    :license: Apache, see LICENSE for more details.
+.. moduleauthor:: Patrick Sanders <psanders@netflix.com>
+"""
+
+from mock import MagicMock, call
+
+from cloudaux.aws.decorators import paginated
+
+
+def test_paginated_single_page():
+    mock_responder = MagicMock()
+    mock_responder.side_effect = [
+        {
+            "NextToken": None,
+            "Data": ["a", "b"]
+        },
+    ]
+
+    @paginated("Data", request_pagination_marker="NextToken", response_pagination_marker="NextToken")
+    def retrieve_letters(**kwargs):
+        return mock_responder(**kwargs)
+
+    result = retrieve_letters()
+    assert result == ["a", "b"]
+    assert mock_responder.call_count == 1
+    mock_responder.assert_has_calls([call()])
+
+
+def test_paginated_multiple_pages():
+    mock_responder = MagicMock()
+    mock_responder.side_effect = [
+        {
+            "NextToken": "1",
+            "Data": ["a", "b"]
+        },
+        {
+            "NextToken": "2",
+            "Data": ["c", "d"]
+        },
+        {
+            "NextToken": None,
+            "Data": ["e", "f"]
+        },
+    ]
+
+    @paginated("Data", request_pagination_marker="NextToken", response_pagination_marker="NextToken")
+    def retrieve_letters(**kwargs):
+        return mock_responder(**kwargs)
+
+    result = retrieve_letters()
+    assert result == ["a", "b", "c", "d", "e", "f"]
+    assert mock_responder.call_count == 3
+    mock_responder.assert_has_calls([call(), call(NextToken="1"), call(NextToken="2")])
+
+
+def test_paginated_multiple_pages_empty_results():
+    mock_responder = MagicMock()
+    mock_responder.side_effect = [
+        {
+            "NextToken": "1",
+            "Data": []
+        },
+        {
+            "NextToken": "2",
+            "Data": []
+        },
+        {
+            "NextToken": "3",
+            "Data": ["e", "f"]
+        },
+        {
+            "NextToken": None,
+            "Data": []
+        },
+    ]
+
+    @paginated("Data", request_pagination_marker="NextToken", response_pagination_marker="NextToken")
+    def retrieve_letters(**kwargs):
+        return mock_responder(**kwargs)
+
+    result = retrieve_letters()
+    assert result == ["e", "f"]
+    assert mock_responder.call_count == 4
+    mock_responder.assert_has_calls([call(), call(NextToken="1"), call(NextToken="2"), call(NextToken="3")])


### PR DESCRIPTION
[Some AWS APIs](https://docs.aws.amazon.com/organizations/latest/APIReference/API_ListChildren.html) may return a response with an empty results list AND a pagination token. The `@paginated` decorator did not support this scenario and broke from its loop on an empty result set. This PR changes the condition to only break if the pagination token is falsy.