### PR TITLE
Fix ReadOnlyAccess arn in different aws partitions

### DIFF
--- a/cloudaux/aws/sts.py
+++ b/cloudaux/aws/sts.py
@@ -142,7 +142,7 @@ def boto3_cached_conn(service, service_type='client', future_expiration_minutes=
         if read_only:
             assume_role_kwargs['PolicyArns'] = [
                 {
-                    'arn': 'arn:aws:iam::aws:policy/ReadOnlyAccess'
+                    'arn': 'arn:{partition}:iam::aws:policy/ReadOnlyAccess'.format(partition=arn_partition)
                 },
             ]
 


### PR DESCRIPTION
Example:
ReadOnlyAccess policy's arn is "arn:aws-cn:iam::aws:policy/ReadOnlyAccess" in aws China.